### PR TITLE
fixed link to C++'s std::bind

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
     C++ offers several compelling alternatives to C-style function pointers such as templates and <a
         href="https://en.cppreference.com/w/cpp/utility/functional/function"
         title="C++ reference page for std::function">std::function</a> with <a
-        href="https://en.cppreference.com/w/cpp/utility/functional/function"
+        href="https://en.cppreference.com/w/cpp/utility/functional/bind"
         title="C++ reference page for std::function">std::bind</a>.
     If you really want to use function pointers in C++, you can still use the same C-style syntax shown above or the
     type aliases below.


### PR DESCRIPTION
Updated the link to C++'s `std::bind`, links properly now instead of linking to `std::function` instead.